### PR TITLE
Optimized configs location.

### DIFF
--- a/qBittorrent/Makefile
+++ b/qBittorrent/Makefile
@@ -55,6 +55,9 @@ CONFIGURE_ARGS += \
 MAKE_VARS += \
 	INSTALL_ROOT=$(PKG_INSTALL_DIR)
 
+define Package/$(PKG_NAME)/conffiles
+/root/.config/qBittorrent/config/qBittorrent.conf
+
 define Package/qBittorrent/install
 	$(INSTALL_DIR) $(1)/usr/man/man1
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/man/man1/qbittorrent-nox.1 $(1)/usr/man/man1/qbittorrent-nox.1
@@ -62,8 +65,8 @@ define Package/qBittorrent/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/qbittorrent-nox $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/qbittorrent $(1)/etc/init.d
-	$(INSTALL_DIR) $(1)/.config/qBittorrent
-	$(CP) ./files/qBittorrent.conf $(1)/.config/qBittorrent
+	$(INSTALL_DIR) $(1)/root/.config/qBittorrent/config
+	$(CP) ./files/qBittorrent.conf $(1)/root/.config/qBittorrent/config/
 	$(INSTALL_DIR) $(1)/root/Downloads
 endef
 

--- a/qBittorrent/Makefile
+++ b/qBittorrent/Makefile
@@ -57,6 +57,7 @@ MAKE_VARS += \
 
 define Package/$(PKG_NAME)/conffiles
 /root/.config/qBittorrent
+endef
 
 define Package/qBittorrent/install
 	$(INSTALL_DIR) $(1)/usr/man/man1

--- a/qBittorrent/Makefile
+++ b/qBittorrent/Makefile
@@ -56,7 +56,7 @@ MAKE_VARS += \
 	INSTALL_ROOT=$(PKG_INSTALL_DIR)
 
 define Package/$(PKG_NAME)/conffiles
-/root/.config/qBittorrent/config/qBittorrent.conf
+/root/.config/qBittorrent
 
 define Package/qBittorrent/install
 	$(INSTALL_DIR) $(1)/usr/man/man1

--- a/qBittorrent/files/qbittorrent
+++ b/qBittorrent/files/qbittorrent
@@ -10,7 +10,7 @@ start_service()
 {
 	echo service qbittorrent start
 	procd_open_instance
-	procd_set_param command $PROG
+	procd_set_param command $PROG --profile="/root/.config"
 	procd_set_param respawn
 	procd_close_instance
 }


### PR DESCRIPTION
解决默认的daemon服务会把配置文件和种子元数据分开保存到**根目录**下的.config和.local目录中导致的混乱问题，以及更新软件包/镜像后配置文件与元数据会丢失的问题。